### PR TITLE
Redis cache delete operation

### DIFF
--- a/src/main/java/org/sunbird/cb/hubservices/network/service/UserConnectionServiceImpl.java
+++ b/src/main/java/org/sunbird/cb/hubservices/network/service/UserConnectionServiceImpl.java
@@ -137,6 +137,8 @@ public class UserConnectionServiceImpl implements UserConnectionService {
         redisCacheMgr.deleteKeyByName(Constants.USER_LIST + Constants.UNDER_SCORE + Constants.RECOMMENDED_USERS + Constants.UNDER_SCORE + Constants.MENTORS + Constants.UNDER_SCORE + fromUserId);
         redisCacheMgr.deleteKeyByName(Constants.USER_LIST + Constants.UNDER_SCORE + Constants.RECOMMENDED_USERS + Constants.UNDER_SCORE + Constants.USERS + Constants.UNDER_SCORE + toUserId);
         redisCacheMgr.deleteKeyByName(Constants.USER_LIST + Constants.UNDER_SCORE + Constants.RECOMMENDED_USERS + Constants.UNDER_SCORE + Constants.MENTORS + Constants.UNDER_SCORE + toUserId);
+        redisCacheMgr.deleteKeyByName(Constants.USER_LIST + Constants.UNDER_SCORE + Constants.CONNECTION_REQUESTED + Constants.UNDER_SCORE + fromUserId);
+        redisCacheMgr.deleteKeyByName(Constants.USER_LIST + Constants.UNDER_SCORE + Constants.CONNECTION_RECIEVED + Constants.UNDER_SCORE + toUserId);
         return response;
     }
 }


### PR DESCRIPTION
1. When add connection is hit we need to clear the cache for from user -requested  and to user  -recieved.