### PR TITLE
Backward Compatibility for Mobile

### DIFF
--- a/src/main/java/org/sunbird/cb/hubservices/model/Node.java
+++ b/src/main/java/org/sunbird/cb/hubservices/model/Node.java
@@ -13,6 +13,7 @@ import java.util.Map;
 public class Node {
 
 	private String userId;
+	private String id;
 	private String createdAt;
 	private String updatedAt;
 	private String fullName;

--- a/src/main/java/org/sunbird/cb/hubservices/serviceimpl/ConnectionService.java
+++ b/src/main/java/org/sunbird/cb/hubservices/serviceimpl/ConnectionService.java
@@ -379,6 +379,7 @@ public class ConnectionService implements IConnectionService {
 							Node node = nodeMap.get(userId);
 							node.setFullName((String) user.get(Constants.FULL_NAME));
 							node.setDepartmentName((String) user.get(Constants.CHANNEL));
+							node.setId(userId);
 							JsonNode root = objectMapper.readTree((String) user.get(Constants.PROFILE_DETAILS));
 							if (root != null) {
 								if (root.hasNonNull(Constants.PROFESSIONAL_DETAILS)) {


### PR DESCRIPTION
1. In the old APIS we were using id for userId so have kept both the attributes. id,userId in the response structure.
2. userId is added as part of new implementation.