### PR TITLE
KB-14131 | BE | Learner Portal | User A can view User B Connections

### DIFF
--- a/src/main/java/org/sunbird/cb/hubservices/network/controller/ConnectionProfileController.java
+++ b/src/main/java/org/sunbird/cb/hubservices/network/controller/ConnectionProfileController.java
@@ -61,11 +61,10 @@ public class ConnectionProfileController {
 	@GetMapping(Constants.FETCH_ESTABLISHED)
 	public ResponseEntity<Response> findEstablished(@RequestHeader(required = false) String org, @RequestHeader String userId,
 			@RequestParam(defaultValue = "50", required = false, name = "pageSize") int pageSize,
-			@RequestParam(defaultValue = "0", required = false, name = "pageNo") int pageNo) {
-
-		Response response = profileService.findProfilesV2(userId, pageNo, pageSize);
-		return new ResponseEntity<>(response, HttpStatus.OK);
-
+			@RequestParam(defaultValue = "0", required = false, name = "pageNo") int pageNo,@RequestHeader(value = Constants.X_AUTH_TOKEN) String authToken) {
+		Response response = profileService.findProfilesV2(userId, pageNo, pageSize, authToken);
+		HttpStatus httpStatus = (HttpStatus) response.get(Constants.ResponseStatus.STATUS);
+		return new ResponseEntity<>(response, httpStatus != null ? httpStatus : HttpStatus.OK);
 	}
 
 	@GetMapping(value = "/relationship/{userId}")

--- a/src/main/java/org/sunbird/cb/hubservices/service/IProfileService.java
+++ b/src/main/java/org/sunbird/cb/hubservices/service/IProfileService.java
@@ -15,7 +15,7 @@ public interface IProfileService {
 
 	public Response findCommonProfileV2(String userId, int offset, int limit);
 
-	public Response findProfilesV2(String userId, int offset, int limit);
+	public Response findProfilesV2(String userId, int offset, int limit, String authToken);
 
 	public Response findProfileRequestedV2(String userId, int offset, int limit, Constants.DIRECTION direction);
 

--- a/src/main/java/org/sunbird/cb/hubservices/serviceimpl/ProfileService.java
+++ b/src/main/java/org/sunbird/cb/hubservices/serviceimpl/ProfileService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.common.recycler.Recycler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
-import org.springframework.util.StringUtils;
 import org.sunbird.cb.hubservices.cache.RedisCacheMgr;
 import org.sunbird.cb.hubservices.cassandra.CassandraOperation;
 import org.sunbird.cb.hubservices.common.auth.AccessTokenValidator;
@@ -78,7 +78,21 @@ public class ProfileService implements IProfileService {
 	}
 
 	@Override
-	public Response findProfilesV2(String userId, int offset, int limit) {
+	public Response findProfilesV2(String userId, int offset, int limit, String authToken) {
+		Response response = new Response();
+		String tokenUserId = accessTokenValidator.fetchUserIdFromAccessToken(authToken);
+		if (StringUtils.isEmpty(tokenUserId)) {
+			logger.warn("ProfileService:findProfilesV2: invalid or expired auth token.");
+			response.put(Constants.ResponseStatus.MESSAGE, Constants.ACCESS_TOKEN_IS_EXPIRED);
+			response.put(Constants.ResponseStatus.STATUS, HttpStatus.UNAUTHORIZED);
+			return response;
+		}
+		if (!tokenUserId.equals(userId)) {
+			logger.warn("ProfileService:findProfilesV2: userId header '{}' does not match token subject '{}'.", userId, tokenUserId);
+			response.put(Constants.ResponseStatus.MESSAGE, "Access denied: userId does not match authenticated user.");
+			response.put(Constants.ResponseStatus.STATUS, HttpStatus.FORBIDDEN);
+			return response;
+		}
 		return connectionService.findAllConnectionsIdsByStatusV2(userId, Constants.Status.APPROVED, offset, limit);
 
 	}


### PR DESCRIPTION
fix(security): enforce object-level authorisation on established connections API

The GET /connections/profile/fetch/established endpoint was vulnerable to horizontal privilege escalation. Any authenticated user could supply an arbitrary userId header to retrieve another user's connections list.

Root cause: the endpoint accepted a plain userId request header with no validation against the caller's authenticated identity. The x-authenticated-user-token forwarded by UIProxy was present but ignored.

Fix:
- Added x-authenticated-user-token as a required header on findEstablished in ConnectionProfileController.
- Updated IProfileService.findProfilesV2() to accept authToken.
- Implemented validation in ProfileService.findProfilesV2():
    - Returns HTTP 401 if token is invalid or expired.
    - Returns HTTP 403 if userId header does not match the token subject.

Files changed:
  ConnectionProfileController.java
  IProfileService.java
  ProfileService.java